### PR TITLE
Add coding guidelines doc and markdownlint config

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,12 @@
+# MD013/line-length - Line length
+MD013:
+  # Number of characters
+  line_length: 140
+
+# MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+# This is for the multiple same headers in CHANGELOG.md
+MD024:
+  # Only check sibling headings
+  allow_different_nesting: true
+  # Only check sibling headings
+  siblings_only: true

--- a/docs/CODING_GUIDELINES.md
+++ b/docs/CODING_GUIDELINES.md
@@ -1,0 +1,81 @@
+# Coding Guidelines
+
+The purpose of this guide is to set a baseline for contributions. These guidelines are not intended to limit the tools at your disposal nor
+to rewire the way you think but rather to encourage good neighbor behavior.
+
+## Language Guidelines
+
+We use **english** language. This is to be consistent everywhere, and to be considerate with developers that do not speak our native language.
+
+Therefore: source code, comments, documentation, commit messages, review comments, and any other kind of contribution *MUST* use english language.
+
+Typos are unavoidable, but try to reduce them by using a spellchecker. Most IDEs can be configured to run one automatically.
+
+## Code Guidelines
+
+* Please use flake8, black and bandit for linting, styling and code-smell, and use mypy to check typing.
+standards (linting, styling and code smells).
+* Always add docstrings to modules, classes and functions.
+* Follow (as best as possible) [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
+* When writing Markdown documents, follow the [markdownlint](https://github.com/DavidAnson/markdownlint) rules. Is possible to integrate it
+with editors or you can use the [cli](https://github.com/igorshubovych/markdownlint-cli).
+
+Generally speaking, be conscious when contributing and try following the same style that the code in the toolkit already has. If you have
+any doubts, just ask us!
+
+This rules will be enforced automatically when making a pull requests, and checks will fail if you do not follow them, resulting in your
+contribution being automatically rejected until fixed.
+
+## Comment Guidelines
+
+Comments in code are a hard thing to write, not because the words are difficult to produce but because it is hard to make relevant comments.
+Too much of it and people do not read comments (and it obfuscates code reading) and too little of it gives you no recourse but to read large
+portions of codebase to get insight as to what a feature/codeblock is doing. Both situations are undesirable and efforts should be made at
+all time to have a please comment reading experience.
+
+As a general rule you would have to comment on decisions you made while coding that are not part of any specification.
+
+In particular you should always comment any decision that:
+
+* Departs from common wisdom or convention (The **why's** are necessary).
+* Takes a significant amount of time to produce. A good rule of thumb here is that if you spent more than 1 hour thinking on how to produce a
+fragment of code that took 2 minutes of wrist time to write you should document your thinking to aid reader and allow for validation.
+* Need to preserve properties of the implementation. This is the case of performance sensitive portions of the codebase, synchronization,
+implementations of security primitives, congestion control algorithms, etc.
+
+As a general rule of what not to comment you should avoid:
+
+* Commenting on structure of programs that is already part of a convention, specified or otherwise.
+* Having pedantic explanations of behavior that can be found by immediate examination of the surrounding code artifacts.
+* Commenting on behavior you cannot attest.
+
+### Branching Guidelines
+
+Currently `master` is the only long term branch and here resides the latest productive codebase.
+A few suggestions of short terms branches naming:
+
+* `fix/something-needs-fix`: Small routine patches in code to features already there.
+* `feature/something-new`: A new feature or a change in a existent feature. Beware of breaking changes that would require a major version bump.
+* `doc/improves-documentation-for-this-feature`: If you add or change documentation with no impact to the source code.
+
+### Git Guidelines
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification to apply in commit messages.
+Also all commits **SHOULD** follow the [seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit):
+
+1. Separate subject from body with a blank line.
+2. Limit the subject line to 72 characters.
+3. Capitalize the subject line.
+4. Do not end the subject line with a period.
+5. Use the imperative mood in the subject line.
+6. Wrap the body at 72 characters.
+7. Use the body to explain what and why vs. how.
+
+Commits such as "fix tests", "now it's working" and many other common messages we find usually in code **WON'T** be accepted.
+
+Ideally we would like to enforce these rules, but we are realistic and understand that it might be a big change for some people.
+So unless deviating heavily from what was stated we might accept your commits even if not following these rules perfectly.
+
+Please avoid taking to much time to deliver code, and always [rebase](https://git-scm.com/docs/git-rebase) your code to avoid reverse merge
+commits.
+We **HATE** reverse merge commits, they make git history tree a mess.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,20 +2,31 @@
 
 ## How to contribute
 
-In order to contribute effectively we provide guidelines to address common case for contributions. Presently we have guides for the following type of changes.
+In order to contribute effectively we provide guidelines to address common case for contributions.
+Presently we have guides for the following type of changes.
 
-* Request For Change (RFC) / Feature Request: These are suggestions / requests for features this library currently does not have. The team evaluates these requests for adequacy / relevance / capacity and overall architectural consistency.
+* Request For Change (RFC) / Feature Request: These are suggestions / requests for features this library currently does not have.
+The team evaluates these requests for adequacy / relevance / capacity and overall architectural consistency.
 * Bug Reports: This are reports of non compliant behavior with this library's specification and other blatantly wrong behavior.
 
-In addition to contributing in the form of Bug Reports and RFCs it is also possible to contribute directly in code with a Pull Request (PR). In the case of a Pull Request you should also indicate the nature of the Pull Request (Feature/Bug/etc.) to help the team asses the Pull Request. If you are enthusiastic about a particular Feature being added or a bug being fixed, a PR is often the quickest way to promote your change as the team does not have to allocate as much resources to process the contribution.
+In addition to contributing in the form of Bug Reports and RFCs it is also possible to contribute directly in code with a Pull Request (PR).
+In the case of a Pull Request you should also indicate the nature of the Pull Request (Feature/Bug/etc.)
+to help the team asses the Pull Request.
+If you are enthusiastic about a particular Feature being added or a bug being fixed,
+a PR is often the quickest way to promote your change as the team does not have to allocate as much resources to process the contribution.
 
-In the case of PRs it is often best to consult with the owner team before embarking on a PR, specially if it's a beefy one. Spending time on a PR that might later be rejected because major discrepancies with vision or competing contributions is an uncomfortable outcome for all involved people.
+In the case of PRs it is often best to consult with the owner team before embarking on a PR, specially if it's a beefy one.
+Spending time on a PR that might later be rejected because major discrepancies with vision or competing contributions is an uncomfortable
+outcome for all involved people.
 
 ## Request For Change / Feature Request
 
-Generally speaking an RFC is needed when you want to add a new component or change an existing one in an incompatible way that might result in a major version bump.
+Generally speaking an RFC is needed when you want to add a new component or change an existing one in an incompatible way that might result
+in a major version bump.
 
-Though it seems a little bureaucratic, the process is in place in order to avoid frustration of a potential contributor by making the discussions take place before any code is written. Once the design and direction is fully agreed then the contributor can work peacefully knowing that their change will be committed.
+Though it seems a little bureaucratic, the process is in place in order to avoid frustration of a potential contributor by making the
+discussions take place before any code is written.
+Once the design and direction is fully agreed then the contributor can work peacefully knowing that their change will be committed.
 
 As of this moment all you need to do is create an issue and use the [Feature Request Template](https://github.com/mercadolibre/ubatch/blob/master/.github/ISSUE_TEMPLATE/feature_request.md).
 
@@ -23,11 +34,15 @@ Please prepend your issue title with `[RFC]` so that's easier to filter.
 
 ## Bug Reports
 
-Bugs are a reality in software. We can't fix what we don't know about, so please report liberally. If you're not sure if something is a bug or not, feel free to file it anyway.
+Bugs are a reality in software. We can't fix what we don't know about, so please report liberally.
+If you're not sure if something is a bug or not, feel free to file it anyway.
 
-Before reporting a bug, please search existing issues and pull requests, as it's possible that someone else has already reported your error. In the off case that you find your issue as fixed/closed, please add a reference to it on your new one.
+Before reporting a bug, please search existing issues and pull requests, as it's possible that someone else has already reported your error.
+In the off case that you find your issue as fixed/closed, please add a reference to it on your new one.
 
-Your issue should contain a title and a clear description of the issue. You should also include as much relevant information as possible and a code sample that demonstrates the issue. The goal of a bug report is to make it easy for yourself - and others - to replicate the bug and develop a fix.
+Your issue should contain a title and a clear description of the issue. You should also include as much relevant information as possible and
+a code sample that demonstrates the issue. The goal of a bug report is to make it easy for yourself - and others - to replicate the bug and
+develop a fix.
 
 Opening an issue is as easy as following [this link](https://github.com/mercadolibre/ubatch/issues/new) and filling out the given template.
 
@@ -35,7 +50,8 @@ Bug reports may also be sent in the form of a [pull request](#pull-request) cont
 
 ## Pull Request
 
-We use the "fork and pull" model [described here](https://help.github.com/articles/about-collaborative-development-models/), where contributors push changes to their personal fork and create pull requests to bring those changes into the source repository.
+We use the "fork and pull" model [described here](https://help.github.com/articles/about-collaborative-development-models/),
+where contributors push changes to their personal fork and create pull requests to bring those changes into the source repository.
 
 Your basic steps to get going:
 
@@ -45,7 +61,9 @@ Your basic steps to get going:
 * Make sure every test passes.
 * Push your commits to GitHub and create a pull request against the corresponding component master branch.
 
-If taking too much time to deliver code, **always** [rebase](https://git-scm.com/docs/git-rebase) towards `master` before asking for a review, and avoid reverse merge commits. We **HATE** reverse merge commits (they make git history tree a mess) and will reject contributions that have them.
+If taking too much time to deliver code, **always** [rebase](https://git-scm.com/docs/git-rebase) towards `master` before asking for a review,
+and avoid reverse merge commits.
+We **HATE** reverse merge commits (they make git history tree a mess) and will reject contributions that have them.
 
 ### Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -260,7 +260,7 @@ See [LICENSE](https://github.com/mercadolibre/ubatch/blob/master/docs/LICENSE) f
 
 ## Contributing
 
-To contribute to this project, take a look to the [contributing file](/docs/CONTRIBUTING.md).
+To contribute to this project, take a look to the [contributing file](/docs/CONTRIBUTING.md) and the [coding guidelines](/docs/CODING_GUIDELINES.md).
 
 ## Maintainers
 


### PR DESCRIPTION
## Linked issue (remove if doesn't apply)

## What does this Pull Request Do?
Add coding guidelines document and add markdownlint configuration.
The markdownlint config set the line length and enable headers with the same name (for CHANGELOG).
We use this tool to maintain a certain style in .md documents. Here more information about the tool:
* [markdownlint](https://github.com/DavidAnson/markdownlint).
* [markdownlint cli](https://github.com/igorshubovych/markdownlint-cli).

## How should this be manually tested?


## Any background context you want to provide?
These changes are to do be compliant with InnerSource initiative. But besides that, is useful to have coding guidelines and a certain style in .md documents.

## Any extra info?


## Checklist

1. Update the [change log](../CHANGELOG.md)
2. Make sure the tests pass
